### PR TITLE
getUploadDirAbs() listen to the upload_dir filter

### DIFF
--- a/lib/classes/Paths.php
+++ b/lib/classes/Paths.php
@@ -115,17 +115,10 @@ class Paths
     }
 
     // ------------ Upload Dir -------------
-    // (can be moved out of wp-content dir. But not (rarely? - I suppose someone could enter dots) out of abspath)
-
     public static function getUploadDirAbs()
     {
-        // Pst: When supporting multisite, we could use wp_upload_dir instead
-        // https://developer.wordpress.org/reference/functions/wp_upload_dir/
-        if ( defined( 'UPLOADS' ) ) {
-            return ABSPATH . rtrim(UPLOADS, '/');
-        } else {
-            return self::getWPContentDirAbs() . '/uploads';
-        }
+        $upload_dir = wp_upload_dir();
+        return $upload_dir['basedir'];
     }
 
     public static function isUploadDirMovedOutOfWPContentDir()


### PR DESCRIPTION
Sites that have a different upload-folder, configured using the "upload_dir" filter, currently gives the warning: WebP Express cannot save a test conversion, because it does not have write access to your upload folder, nor your wp-content folder. Please provide!

This fix uses the built in wp_upload_dir() to get the correct upload folder.

Exemple of plugin that conflicts:
https://github.com/puggan/upload_abs_path/blob/master/upload_abs_path.php