### PR TITLE
fix: use deleteConverterOption in updateConverterOptions

### DIFF
--- a/lib/options/js/converters.js
+++ b/lib/options/js/converters.js
@@ -350,13 +350,12 @@ function updateConverterOptions() {
             setConverterOption(converter, 'quality', 'auto');
             setConverterOption(converter, 'max-quality', document.getElementById(id + '_max_quality').value);
         } else {
-            //delete converter['options']['quality'];
             setConverterOption(converter, 'quality', 'inherit');
-            delete converter['options']['max-quality'];
+            deleteConverterOption(converter, 'max-quality');
         }
     } else {
-        delete converter['options']['quality'];
-        delete converter['options']['max-quality'];
+        deleteConverterOption(converter, 'quality');
+        deleteConverterOption(converter, 'max-quality');
     }
 
     switch (converter['converter']) {


### PR DESCRIPTION
Updating the ewww api key resulted in a JS error, since options was not defined on the ewww converter. Using the deleteConverterOption checks if the options object is on the converter before deleting keys from it.