### PR TITLE
Update webp-realizer.php

### DIFF
--- a/wod/webp-realizer.php
+++ b/wod/webp-realizer.php
@@ -24,7 +24,7 @@ function exitWithError($msg) {
 
 // Protect against directly accessing webp-on-demand.php
 // Only protect on Apache. We know for sure that the method is not reliable on nginx. We have not tested on litespeed yet, so we dare not.
-if (stripos($_SERVER["SERVER_SOFTWARE"], 'apache') !== false) {
+if (stripos($_SERVER["SERVER_SOFTWARE"], 'apache') !== false && stripos($_SERVER["SERVER_SOFTWARE"], 'nginx') === false) {
     if (strpos($_SERVER['REQUEST_URI'], 'webp-realizer.php') !== false) {
         exitWithError('It seems you are visiting this file (plugins/webp-express/wod/webp-realizer.php) directly. We do not allow this.');
         exit;


### PR DESCRIPTION
Some hosts like WPEngine use Apache & nginx so we need to check for nginx explicitly if we know this method is unreliable