### PR TITLE
*Add wp-rocket compatibility

### DIFF
--- a/lib/classes/AlterHtmlHelper.php
+++ b/lib/classes/AlterHtmlHelper.php
@@ -89,6 +89,10 @@ class AlterHtmlHelper
      */
     public static function isImageUrlHere($imageUrl, $baseUrl, $baseDir)
     {
+        
+        if ( function_exists( 'get_rocket_option' ) && 0 < (int) get_rocket_option( 'cdn' ) ) {
+            $baseUrl  = get_rocket_cdn_url( $baseUrl, [ 'all', 'images' ] );
+        }
 
         $srcPathRel = self::getRelUrlPath($imageUrl, $baseUrl);
 
@@ -208,6 +212,16 @@ class AlterHtmlHelper
             self::$options = json_decode(Option::getOption('webp-express-alter-html-options', null), true);
         }
 
+        if ( function_exists( 'get_rocket_option' ) && 0 < (int) get_rocket_option( 'cdn' ) ) {
+            self::$options['bases']['content'][1] = get_rocket_cdn_url( self::$options['bases']['content'][1], [
+                'all',
+                'images',
+            ] );
+            self::$options['bases']['uploads'][1] = get_rocket_cdn_url( self::$options['bases']['uploads'][1], [
+                'all',
+                'images',
+            ] );
+        }
 
         // Currently we do not handle relative urls - so we skip
         if (!preg_match('#^https?://#', $sourceUrl)) {


### PR DESCRIPTION
This is probably the first of what should be many in the future. Due to the plugin checking urls, it needs to modify the config on the fly to handle CDN settings for wp-rocket. It is also not done on save so that you don't need to re-save the config after changing rockets config, as that's going to be seen as a mystery bug and frustration.