### PR TITLE
Fix false negative in has-mod-header on setups that strip non-standard headers

### DIFF
--- a/htaccess-capability-tests/has-mod-header/.htaccess
+++ b/htaccess-capability-tests/has-mod-header/.htaccess
@@ -1,3 +1,5 @@
 <IfModule mod_headers.c>
-    RequestHeader set HEADERFORTEST "test"
+	# Certain hosts seem to strip non-standard request headers,
+	# so we use a standard one to avoid a false negative
+    RequestHeader set User-Agent "webp-express-test"
 </IfModule>

--- a/htaccess-capability-tests/has-mod-header/test.php
+++ b/htaccess-capability-tests/has-mod-header/test.php
@@ -2,8 +2,8 @@
 
 //echo '<pre>'. print_r($_SERVER, 1) . '</pre>';
 
-if (isset($_SERVER['HTTP_HEADERFORTEST'])) {
-    echo ($_SERVER['HTTP_HEADERFORTEST'] == 'test' ? 1 : 0);
-    exit;
+if (isset($_SERVER['HTTP_USER_AGENT'])) {
+    echo  $_SERVER['HTTP_USER_AGENT'] == 'webp-express-test' ? 1 : 0;
+} else {
+	echo 0;
 }
-echo '0';


### PR DESCRIPTION
Relevant issue: https://wordpress.org/support/topic/error-mod_header-with-litespeed-enterprise/

This PR fixes a problem with WebP Express on my LiteSpeed host. The plugin was reporting that `mod_headers` was not available even though it was installed and worked correctly. After some investigation it turned out the `has-mod-header` test was giving a false negative – for some reason, setting `HEADERFORTEST: test` doesn't work, but e.g. `User-Agent:  test` works fine. [Here's a live demo on my site](http://magazynwizje.pl/wp-content/test/test.php).

I'm not sure what's causing this behavior (and have limited priviledges on the host, so debugging is hard), but from my testing it looks like some part of our setup doesn't allow for adding non-standard request headers with `RequestHeader set ...`. disabling modsecurity doesn't help. (response headers work fine though).

This PR changes `has-mod-header` to put the test payload into the `User-Agent` header, which is always "allowed through". Any non-essential header could be used here (`From: webp-express-test`, `Referer: webp-express-test`, etc) but I used `User-Agent` because it seems least likely to break something.