### PR TITLE
Fixes "Path is outside resolved document root" on file conversion attempts in Windows (#391).

### DIFF
--- a/lib/classes/SanityCheck.php
+++ b/lib/classes/SanityCheck.php
@@ -315,12 +315,13 @@ class SanityCheck
             // Cannot resolve document root, so cannot test if in document root
             return $input;
         }
-        $docRootSymLinksExpanded = rtrim($docRootSymLinksExpanded, '/');
+        $docRootSymLinksExpanded = rtrim($docRootSymLinksExpanded, '\\/');
         $docRootSymLinksExpanded = self::absPathExists($docRootSymLinksExpanded, 'Document root does not exist!');
         $docRootSymLinksExpanded = self::absPathExistsAndIsDir($docRootSymLinksExpanded, 'Document root is not a directory!');
 
+        $directorySeparator = self::isOnMicrosoft() ? '\\' : '/';
         $errorMsg = 'Path is outside resolved document root (' . $docRootSymLinksExpanded . ')';
-        self::pathBeginsWithSymLinksExpanded($input, $docRootSymLinksExpanded . '/', $errorMsg);
+        self::pathBeginsWithSymLinksExpanded($input, $docRootSymLinksExpanded . $directorySeparator, $errorMsg);
 
         return $input;
     }


### PR DESCRIPTION
In class SanityCheck, makes sure the appended directory separator in absPathIsInDocRoot() is consistent with the OS so that the strpos check in pathBeginsWith() doesn't return false in Windows when comparing the resulting value to the $input string.

https://github.com/rosell-dk/webp-express/blob/3ec6d035a4539f40ea9abc7edfbe7e59cf0a8b71/lib/classes/SanityCheck.php#L142