### PR TITLE
fix for converting files with non ascii characters

### DIFF
--- a/wod/autoloader.php
+++ b/wod/autoloader.php
@@ -1,4 +1,5 @@
 <?php
+setlocale(LC_CTYPE, "C.UTF-8");
 define('WOD_DIR', __DIR__);
 function webpexpress_autoloader($class) {
     if (strpos($class, 'WebPExpress\\') === 0) {


### PR DESCRIPTION
regarding #386 . Sets locale LC_CTYPE to C.UTF-8 (compared to the default C locale which doesn't allow UTF-8 characters).
This way, escapeshellargs() doesn't strip UTF-8 characters (like ä, ö and ü).