### PR TITLE
testing for WP_Error before attempting to access array in SelfTestHelper

### DIFF
--- a/lib/classes/SelfTestHelper.php
+++ b/lib/classes/SelfTestHelper.php
@@ -196,14 +196,14 @@ class SelfTestHelper
 
         $results = [];
         $wpResult = wp_remote_get($requestUrl, $args);
-        if (!isset($wpResult['headers'])) {
-            $wpResult['headers'] = [];
-        }
-        $results[] = $wpResult;
         if (is_wp_error($wpResult)) {
             $log[] = 'The remote request errored';
             return [false, $log, $results];
         }
+        if (!isset($wpResult['headers'])) {
+            $wpResult['headers'] = [];
+        }
+        $results[] = $wpResult;
         $responseCode = $wpResult['response']['code'];
 
         $log[] = 'Response: ' . $responseCode . ' ' . $wpResult['response']['message'];


### PR DESCRIPTION
A fatal error is thrown when the conditional statement (linked below) attempts to access a `WP_Error` object as an array. I've moved the `is_wp_error()` check a few lines up which allows the error to be caught and handled properly.

https://github.com/rosell-dk/webp-express/blob/ccc5ee64a6785e36de9fca40cce09977837cd41f/lib/classes/SelfTestHelper.php#L198-L206