### PR TITLE
Option to manually add Content Filtering Custom hooks

### DIFF
--- a/lib/classes/AlterHtmlInit.php
+++ b/lib/classes/AlterHtmlInit.php
@@ -107,6 +107,21 @@ class AlterHtmlInit
             add_filter( 'the_excerpt', '\\WebPExpress\\AlterHtmlInit::alterHtml', 99999 );
             add_filter( 'post_thumbnail_html', '\\WebPExpress\\AlterHtmlInit::alterHtml', 99999);
 
+            // Run custom Filtering Hooks for support 3rd plugins that do not hardcode above
+            $hooks_list = Option::getOption('webp-express-alter-html-content-hooks-list');
+            if ( ! empty( $hooks_list ) ) {
+                $hooks_list = explode( "\n", $hooks_list );
+                if ( ! empty( $hooks_list ) ) {
+                    $hooks_list = array_map( 'trim', $hooks_list );
+
+                    foreach ( $hooks_list as $hook_tag ) {
+                        if ( ! empty( $hook_tag ) ) {
+                            add_filter( $hook_tag, '\\WebPExpress\\AlterHtmlInit::alterHtml', 99999);
+                        }
+                    }
+                }
+            }
+
 
             /*
             TODO:

--- a/lib/classes/Config.php
+++ b/lib/classes/Config.php
@@ -83,6 +83,7 @@ class Config
                 'enabled' => false,
                 'replacement' => 'picture',          // "picture" or "url"
                 'hooks' => 'ob',             // "content-hooks" or "ob"
+                'content-hooks-list' => '',     // hooks list for hooks field is "content-hooks"
                 'only-for-webp-enabled-browsers' => true,     // If true, there will be two HTML versions of each page
                 'only-for-webps-that-exists' => false,
                 'alter-html-add-picturefill-js' => true,
@@ -394,6 +395,7 @@ class Config
 
         Option::updateOption('webp-express-alter-html', $config['alter-html']['enabled'], true);
         Option::updateOption('webp-express-alter-html-hooks', $config['alter-html']['hooks'], true);
+        Option::updateOption('webp-express-alter-html-content-hooks-list', $config['alter-html']['content-hooks-list'], '');
         Option::updateOption('webp-express-alter-html-replacement', $config['alter-html']['replacement'], true);
         Option::updateOption('webp-express-alter-html-add-picturefill-js', (($config['alter-html']['replacement'] == 'picture') && (isset($config['alter-html']['alter-html-add-picturefill-js']) && $config['alter-html']['alter-html-add-picturefill-js'])), true);
 

--- a/lib/options/js/0.16.0/page.js
+++ b/lib/options/js/0.16.0/page.js
@@ -264,6 +264,22 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    // Show/hide "Add custom filtering hooks from theme or plugins here, 1 per line" when "Where to replace" is changed
+    if (el('alter_html_hooks_content_hooks') && el('alter_html_content_hooks_options_div')) {
+        el('alter_html_content_hooks_options_div').classList.add('effect-opacity');
+        function updateFilteringHooksVisibility() {
+            toggleVisibility('alter_html_content_hooks_options_div', el('alter_html_hooks_content_hooks').checked);
+        }
+        updateFilteringHooksVisibility();
+
+        el('alter_html_hooks_content_hooks').addEventListener('change', function() {
+            updateFilteringHooksVisibility();
+        });
+        el('alter_html_hooks_ob').addEventListener('change', function() {
+            updateFilteringHooksVisibility();
+        });
+    }
+
     if (el('ui_show_alter_html_chart') && el('alter_html_comparison_chart')) {
         var elm = el('alter_html_comparison_chart');
         elm.style['maxHeight'] = (elm.clientHeight + 80) + 'px';

--- a/lib/options/options/alter-html/alter-html-options.inc
+++ b/lib/options/options/alter-html/alter-html-options.inc
@@ -183,14 +183,33 @@ namespace WebPExpress;
                     '<p></p>',
                     'no-margin-left set-margin-right');
                 ?></label>
+                <ul style="margin-left: 20px; margin-top: 5px"><li>
                 <?php
-                webpexpress_radioButtons('alter-html-hooks', $config['alter-html']['hooks'], [
-                    'content-hooks' => 'Use content filtering hooks (the_content, the_excerpt, etc)',
-                    'ob' => 'The complete page (using output buffering)</em>',
-                ], [
-                ]
+                webpexpress_radioButton(
+                  'alter-html-hooks',
+                  'content-hooks',
+                  'Use content filtering hooks (the_content, the_excerpt, etc)',
+                  $config['alter-html']['hooks']     // PS: the function takes care of the escaping
                 );
                 ?>
+                </li>
+                <li><div id="alter_html_content_hooks_options_div" style="margin-left:18px; margin-bottom: 13px;">
+                    <div style="margin:10px 0 0 10px;">
+                        <label for="alter_html_content_hooks_list">Add custom filtering hooks from theme or plugins here, 1 per line:</label><br/>
+                        <textarea id="alter_html_content_hooks_list" name="alter-html-content-hooks-list" cols="50" rows="4"><?php echo stripslashes( $config['alter-html']['content-hooks-list'] ); ?></textarea>
+                    </div>
+                </div></li>
+                <li>
+                <?php
+                webpexpress_radioButton(
+                  'alter-html-hooks',
+                  'ob',
+                  'The complete page (using output buffering)',
+                  $config['alter-html']['hooks']  // PS: the function takes care of the escaping
+                );
+                ?>
+                </li>
+                </ul>
             </div>
             <div style="margin-top: 20px">
                 <label>CDN hostname(s) / hostname alias(es) <?php echo helpIcon(

--- a/lib/options/submit.php
+++ b/lib/options/submit.php
@@ -456,6 +456,7 @@ $sanitized = [
         'content-hooks',
         'ob'
     ]),
+    'alter-html-content-hooks-list' => str_replace( array( "'", '"', '\\' ), '', sanitize_textarea_field( $_POST['alter-html-content-hooks-list'] ) ),
     'alter-html-hostname-aliases' => webpexpress_getSanitizedAlterHtmlHostnameAliases(),
 
 
@@ -528,6 +529,7 @@ if ($sanitized['operation-mode'] != 'no-conversion') {
 
 $config['alter-html']['replacement'] = $sanitized['alter-html-replacement'];
 $config['alter-html']['hooks'] = $sanitized['alter-html-hooks'];
+$config['alter-html']['content-hooks-list'] = $sanitized['alter-html-content-hooks-list'];
 $config['alter-html']['hostname-aliases'] = $sanitized['alter-html-hostname-aliases'];
 
 


### PR DESCRIPTION
This pull request adds a textra box to the Use custom filtering hooks setting where the user can add any theme or plugin custom filter hooks.
The textra box has Help text and is only enabled when the Use Custom Filtering Hooks option is selected.
See screenshot
[![Image from Gyazo](https://i.gyazo.com/0807fa5e7089ec481cab479c34e690cc.png)](https://gyazo.com/0807fa5e7089ec481cab479c34e690cc)