### PR TITLE
Bedrock symbolic link

### DIFF
--- a/lib/classes/SanityCheck.php
+++ b/lib/classes/SanityCheck.php
@@ -307,7 +307,6 @@ class SanityCheck
 
         // Use realpath to expand symbolic links and check if it exists
         $docRootSymLinksExpanded = @realpath($docRoot);
-
         if ($docRootSymLinksExpanded === false) {
             // probably outside open basedir restriction.
             //$errorMsg = 'Cannot resolve document root';

--- a/lib/classes/SanityCheck.php
+++ b/lib/classes/SanityCheck.php
@@ -307,6 +307,12 @@ class SanityCheck
 
         // Use realpath to expand symbolic links and check if it exists
         $docRootSymLinksExpanded = @realpath($docRoot);
+        
+        // See if $filePath begins with the realpath of the $docRoot + '/'. If it does, we are done and OK!
+        if (strpos($input, $docRootSymLinksExpanded . '/') === 0) {
+            return $input;
+        }
+
         if ($docRootSymLinksExpanded === false) {
             // probably outside open basedir restriction.
             //$errorMsg = 'Cannot resolve document root';

--- a/lib/classes/SanityCheck.php
+++ b/lib/classes/SanityCheck.php
@@ -307,11 +307,6 @@ class SanityCheck
 
         // Use realpath to expand symbolic links and check if it exists
         $docRootSymLinksExpanded = @realpath($docRoot);
-        
-        // See if $filePath begins with the realpath of the $docRoot + '/'. If it does, we are done and OK!
-        if (strpos($input, $docRootSymLinksExpanded . '/') === 0) {
-            return $input;
-        }
 
         if ($docRootSymLinksExpanded === false) {
             // probably outside open basedir restriction.
@@ -321,6 +316,12 @@ class SanityCheck
             // Cannot resolve document root, so cannot test if in document root
             return $input;
         }
+
+        // See if $filePath begins with the realpath of the $docRoot + '/'. If it does, we are done and OK!
+        if (strpos($input, $docRootSymLinksExpanded . '/') === 0) {
+            return $input;
+        }
+
         $docRootSymLinksExpanded = rtrim($docRootSymLinksExpanded, '\\/');
         $docRootSymLinksExpanded = self::absPathExists($docRootSymLinksExpanded, 'Document root does not exist!');
         $docRootSymLinksExpanded = self::absPathExistsAndIsDir($docRootSymLinksExpanded, 'Document root is not a directory!');


### PR DESCRIPTION
Hey @rosell-dk 

The fix is trying to cover the issue that within Bedrock structure where the $docRoot has a symbolic link.

For example, if the document root has a symbolic link like 

/home/projectA/public_html --> /home/projectA/deploy/release/src

then $docRoot would be `/home/projectA/public_html`, $input would be `/home/projectA/deploy/release/src/app/plugin...`, line 303 would be false.

The solution here is since we are getting `realpath` of the $docRoot, just apply the same check against the its realpath.