### PR TITLE
Change AlterHtmlHelper: Adds check to ensure array key exists to avoi…

### DIFF
--- a/lib/classes/AlterHtmlHelper.php
+++ b/lib/classes/AlterHtmlHelper.php
@@ -238,7 +238,7 @@ class AlterHtmlHelper
         self::getOptions();
 
         // Fail for webp-disabled  browsers (when "only-for-webp-enabled-browsers" is set)
-        if ((self::$options['only-for-webp-enabled-browsers']) && (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false)) {
+        if (!isset($_SERVER['HTTP_ACCEPT']) || ((self::$options['only-for-webp-enabled-browsers']) && (strpos($_SERVER['HTTP_ACCEPT'], 'image/webp') === false))) {
             return $returnValueOnFail;
         }
 


### PR DESCRIPTION
Hey mate,

I have hundreds of `[11-Mar-2021 10:05:45 UTC] PHP Notice:  Undefined index: HTTP_ACCEPT in /var/www/html/wp-content/plugins/webp-express/lib/classes/AlterHtmlHelper.php on line 241` 

I added a quick check just to ensure the key exists, to avoid flooding the wp-debug.log.

Cheers!