### PR TITLE
Correctly sanitize PNG alpha quality

### DIFF
--- a/lib/options/submit.php
+++ b/lib/options/submit.php
@@ -425,7 +425,7 @@ $sanitized = [
         'lossless',
         'auto'
     ]),
-    'alpha-quality' => webpexpress_getSanitizedQuality('png-quality', 80),
+    'alpha-quality' => webpexpress_getSanitizedQuality('alpha-quality', 80),
     'convert-on-upload' => isset($_POST['convert-on-upload']),
     'converters' => webpexpress_getSanitizedConverters(),
 


### PR DESCRIPTION
A small PR to correctly update PNG alpha quality when saving settings (currently the PNG alpha quality value gets overwritten with the PNG quality value)