### PR TITLE
Add custom port support

### DIFF
--- a/lib/classes/AlterHtmlHelper.php
+++ b/lib/classes/AlterHtmlHelper.php
@@ -221,7 +221,8 @@ class AlterHtmlHelper
         // Fix scheme (use same as source)
         $sourceUrlComponents = parse_url($sourceUrl);
         $destUrlComponents = parse_url($destUrl);
-        return $sourceUrlComponents['scheme'] . '://' . $sourceUrlComponents['host'] . $destUrlComponents['path'];
+        $port = $sourceUrlComponents['port'] ? ":" . $sourceUrlComponents['port'] : "";
+        return $sourceUrlComponents['scheme'] . '://' . $sourceUrlComponents['host'] . $port . $destUrlComponents['path'];
     }
 
 


### PR DESCRIPTION
If Wordpress is accessed from another port than 80 or 443 (URL looks like http[s]://domain:[PORT NUMBER]/path) then WebP Express will now be able to point to the correct port instead of using HTTP's default.

At the moment it would drop the port and end up not finding the file.