### PR TITLE
Fix "Undefined index: HTTP_REFERER"

### DIFF
--- a/lib/classes/PluginDeactivate.php
+++ b/lib/classes/PluginDeactivate.php
@@ -29,7 +29,7 @@ class PluginDeactivate
                 $msg
             );
 
-            wp_redirect( $_SERVER['HTTP_REFERER']);
+            wp_redirect(admin_url('options-general.php?page=webp_express_settings_page'));
             exit;
         }
     }

--- a/lib/options/submit.php
+++ b/lib/options/submit.php
@@ -790,6 +790,6 @@ if (!$result['saved-both-config']) {
     }
 }
 
-wp_redirect( $_SERVER['HTTP_REFERER']);
+wp_redirect(admin_url('options-general.php?page=webp_express_settings_page'));
 
 exit();


### PR DESCRIPTION
![2021-08-11-170553_873x76_scrot](https://user-images.githubusercontent.com/2728418/129055091-b2643998-d504-483b-8bf7-953ad55421d5.png)

On a local machine I encountered the above error. And [as per this StackOverflow answer](https://stackoverflow.com/a/4517649), `$_SERVER['HTTP_REFERER']` is not reliable.

So instead, I redirect to the options page as is done in other places of the plugin already.