### PR TITLE
Fix : Ajax not returning response when there is encoding issue in res…

### DIFF
--- a/lib/classes/Convert.php
+++ b/lib/classes/Convert.php
@@ -288,8 +288,22 @@ class Convert
 
         $result['nonce-tick'] = $nonceTick;
 
+        
+        $result = self::utf8ize($result);
+
         echo json_encode($result, JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK | JSON_PRETTY_PRINT);
+
         wp_die();
     }
 
+     function utf8ize($d) {
+        if (is_array($d)) {
+            foreach ($d as $k => $v) {
+                $d[$k] = self::utf8ize($v);
+            }
+        } else if (is_string ($d)) {
+            return utf8_encode($d);
+        }
+        return $d;
+    }
 }


### PR DESCRIPTION
When bulk converting I came across and issue where response stopped returning i.e. could not process the conversion list. by utf8 encoding the results array before converting to JSON ensures that the JSON encoding happens and the result does not return blank.

The new utf8ize function should be moved to a new class or I can forget the function and move the $results array loop within processing function.