### PR TITLE
 Handling Uncaught Fatal Exception during .htaccess read failure

### DIFF
--- a/lib/classes/FileHelper.php
+++ b/lib/classes/FileHelper.php
@@ -224,8 +224,9 @@ class FileHelper
         $return = false;
         try {
             $handle = @fopen($filename, "r");
-        } catch (\ErrorException $e) {
+        } catch (\ErrorException $exception) {
             $handle = false;
+            error_log($exception->getMessage());
         }
         if ($handle !== false) {
             // Return value is either file content or false

--- a/lib/classes/FileHelper.php
+++ b/lib/classes/FileHelper.php
@@ -222,7 +222,11 @@ class FileHelper
         }
 
         $return = false;
-        $handle = @fopen($filename, "r");
+        try {
+            $handle = @fopen($filename, "r");
+        } catch (\ErrorException $e) {
+            $handle = false;
+        }
         if ($handle !== false) {
             // Return value is either file content or false
             if (filesize($filename) == 0) {


### PR DESCRIPTION
The plugin shows a Fatal Error when the fopen function cannot find the .htaccess in its default location.
This is always the case when using frameworks with different wp directory structure like bedrock.
Handling this exception as a file handling failure at least fixes the otherwise unavoidable blank settings page with the fatal error message and lets the user configure the rules manually.

