### PR TITLE
PHP 8.2: remove deprecation message

### DIFF
--- a/lib/classes/ImageRoot.php
+++ b/lib/classes/ImageRoot.php
@@ -6,9 +6,9 @@ use \WebPExpress\PathHelper;
 
 class ImageRoot
 {
-
     public $id;
-    
+    private $imageRootDef;
+
     /**
      * Constructor.
      *

--- a/lib/classes/ImageRoots.php
+++ b/lib/classes/ImageRoots.php
@@ -6,6 +6,9 @@ use \WebPExpress\ImageRoot;
 
 class ImageRoots
 {
+    private $imageRootsDef;
+    private $imageRoots;
+
     /**
      * Constructor.
      *

--- a/lib/classes/Paths.php
+++ b/lib/classes/Paths.php
@@ -792,7 +792,7 @@ APACHE
      */
     public static function getWebPExpressPluginUrl()
     {
-        return untrailingslashit(plugins_url(null, WEBPEXPRESS_PLUGIN));
+        return untrailingslashit(plugins_url('', WEBPEXPRESS_PLUGIN));
     }
 
     public static function getWebPExpressPluginUrlPath()


### PR DESCRIPTION
In PHP 8.2 activating this plugin will give a white screen of death. This PR fixes the bug and restores the plugin's functionality.