### PR TITLE
Fix correct server root path SanityCheck.php

### DIFF
--- a/lib/classes/SanityCheck.php
+++ b/lib/classes/SanityCheck.php
@@ -290,7 +290,8 @@ class SanityCheck
             return $input;
         }
 
-        $docRoot = self::absPath($_SERVER["DOCUMENT_ROOT"]);
+        $correctRootPath = self::correctRootPath();
+        $docRoot = self::absPath($correctRootPath);
         $docRoot = rtrim($docRoot, '/');
 
         try {
@@ -325,6 +326,16 @@ class SanityCheck
         self::pathBeginsWithSymLinksExpanded($input, $docRootSymLinksExpanded . $directorySeparator, $errorMsg);
 
         return $input;
+    }
+
+    /**
+     * @return string
+     */
+    public static function correctRootPath()
+    {
+       $path = rtrim(realpath($_SERVER['DOCUMENT_ROOT']), '/');
+
+       return dirname($path);
     }
 
     public static function absPathExists($input, $errorMsg = 'Path does not exist or it is outside restricted basedir')


### PR DESCRIPTION
we got issue where server root path has inccorect folder like

.../ca/site

but need that detect real root path like

../ca

and comaprison then works inccorect here 

if (!(strpos($input, $beginsWith) === 0)) {

because - $input - correct symlink path
root project path - $beginsWith - incorrect.

please check on your side, my changes should works for all.