### PR TITLE
Add `href` to attributes to be searched

### DIFF
--- a/lib/classes/AlterHtmlImageUrls.php
+++ b/lib/classes/AlterHtmlImageUrls.php
@@ -23,7 +23,7 @@ class AlterHtmlImageUrls extends ImageUrlReplacer
     public function attributeFilter($attrName) {
         // Allow "src", "srcset" and data-attributes that smells like they are used for images
         // The following rule matches all attributes used for lazy loading images that we know of
-        return preg_match('#^(src|srcset|poster|(data-[^=]*(lazy|small|slide|img|large|src|thumb|source|set|bg-url)[^=]*))$#i', $attrName);
+        return preg_match('#^(src|srcset|href|poster|(data-[^=]*(lazy|small|slide|img|large|src|thumb|source|set|bg-url)[^=]*))$#i', $attrName);
 
         // If you want to limit it further, only allowing attributes known to be used for lazy load,
         // use the following regex instead:


### PR DESCRIPTION
Currently, `<link>` and `<a>` tags are searched by default: https://github.com/rosell-dk/webp-express/blob/18447e42cde58a3e876fa4184f8fa027bd258228/vendor/rosell-dk/dom-util-for-webp/src/ImageUrlReplacer.php#L41-L44

But their `href` attributes aren’t searched, with the result that URLs in `<link>` and `<a>` don’t actually get replaced even when the relevant images have been converted.

This PR fixed the issue.